### PR TITLE
fix: remove labels from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,4 @@ updates:
       timezone: "America/Los_Angeles"
     commit-message:
       prefix: "chore: "
-    labels:
-      - dependencies
     target-branch: "main"


### PR DESCRIPTION
Remove `dependencies` label as it is useless for this repository.