### PR TITLE
chore: add webconsole specific workflow

### DIFF
--- a/.github/workflows/webconsole/build-ui.yml
+++ b/.github/workflows/webconsole/build-ui.yml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 Canonical Ltd.
+name: Build Webconsole UI
+
+on:
+  workflow_call:
+    inputs:
+      branch_name:
+        description: "Name of the branch to checkout"
+        required: false
+        type: string
+        default: ${{ github.ref }}
+
+jobs:
+  build-ui:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch_name }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Build
+        run: make webconsole-ui


### PR DESCRIPTION
This PR adds a webconsole specific workflow allowing to build the UI from the common GHAs repository.
The workflow is created in a sub-directory of `workflows`. This pattern will be used also for all the modules requiring specific workflows (such as `upf` and `bess`).