### PR TITLE
chore: explicitly enable caching for Go setup action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+          cache: true
 
       - name: Build
         run: go build ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           ref: ${{ inputs.branch_name }}
 
-      - name: Setup
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+          cache: true
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6.5.2

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+          cache: true
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3.4.0

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           ref: ${{ inputs.branch_name }}
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+          cache: true
 
       - uses: dominikh/staticcheck-action@v1.3.1
         with:

--- a/.github/workflows/webconsole-build-ui.yml
+++ b/.github/workflows/webconsole-build-ui.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+          cache: true
 
       - name: Build
         run: make webconsole-ui


### PR DESCRIPTION
This PR explicitly enables caching for the `setup-go` action, standardizing the structure of all the workflows.