### PR TITLE
fix: use workflow_call to be called by other workflows

### DIFF
--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -3,7 +3,7 @@
 name: Stale issue/pr
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       days_before_stale:
         description: "Days before stale"


### PR DESCRIPTION
Replace `workflow_dispatch` with `workflow_call` in order to call this workflow by other workflows.