### PR TITLE
Fix issue with tag-github due to not finding action.yml file

### DIFF
--- a/.github/workflows/tag-github.yml
+++ b/.github/workflows/tag-github.yml
@@ -1,5 +1,6 @@
-# SPDX-License-Identifier: Apache-2.0
 # Copyright 2025 Canonical Ltd.
+# SPDX-FileCopyrightText: 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 name: Tag GitHub
 
 on:
@@ -75,6 +76,6 @@ jobs:
 
       - name: Create release
         if: steps.version-change.outputs.changed == 'true'
-        uses: ./.github/actions/create-github-release
+        uses: omec-project/.github/.github/actions/create-github-release@main
         with:
           VERSION: ${{ steps.version-change.outputs.version }}


### PR DESCRIPTION
See issue here: https://github.com/omec-project/nas/actions/runs/14256419194
```
Annotations
1 error
tag-github / tag-github
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/nas/nas/.github/actions/create-github-release'. Did you forget to run actions/checkout before running your local action?
```