### PR TITLE
Still not possible to create release using gh client. Switching to API

### DIFF
--- a/.github/workflows/tag-github.yml
+++ b/.github/workflows/tag-github.yml
@@ -74,17 +74,20 @@ jobs:
            exit 1
           fi
 
-      - name: Create release
+      - name: Create release using REST API
         if: steps.version-change.outputs.changed == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_OMEC_PAT }}
         run: |
-          echo "$GITHUB_TOKEN" | gh auth login --with-token
-          if gh release create "${{ inputs.VERSION }}" --generate-notes; then
-            echo "Release ${{ inputs.VERSION }} created ✅" >> "$GITHUB_STEP_SUMMARY"
-            echo "Release ${{ inputs.VERSION }} created ✅"
-          else
-            echo "Failed to create release ${{ inputs.VERSION }} ❌" >> "$GITHUB_STEP_SUMMARY"
-            echo "Failed to create release ${{ inputs.VERSION }} ❌"
-          fi
-          gh auth logout
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GH_OMEC_PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/releases \
+            -d '{
+              "tag_name": "v${{ steps.version-change.outputs.version }}",
+              "target_commitish": "${{ github.event.repository.default_branch }}",
+              "name": "v${{ steps.version-change.outputs.version }}",
+              "draft": false,
+              "prerelease": false,
+              "generate_release_notes": true
+              }'


### PR DESCRIPTION
When trying to use `gh` client, it requests for "manual" intervention to login as it can be seen here: https://github.com/omec-project/nas/actions/runs/14274818114/job/40015765574. This PR reverts this and uses the REST API, as it was done before