### PR TITLE
Fix issues with `push`-related GHAs

### DIFF
--- a/.github/workflows/branch-release.yml
+++ b/.github/workflows/branch-release.yml
@@ -1,25 +1,27 @@
-# SPDX-License-Identifier: Apache-2.0
 # Copyright 2025 Canonical Ltd.
+# SPDX-FileCopyrightText: 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 name: Branch Release
 
 on:
   workflow_call:
-
-  workflow_run:
-    workflows:
-      - "Tag GitHub"
-    types:
-      - completed
+    inputs:
+      release_branch:
+        required: true
+        type: string
+      version_branch:
+        required: true
+        type: string
 
 jobs:
   branch-release:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.outputs.release_branch == 'true' }}
-    env:
-      GITHUB_TOKEN: ${{ secrets.GH_OMEC_PAT }}
+    if: ${{ inputs.release_branch == 'true' }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: peterjgrainger/action-create-branch@v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_OMEC_PAT }}
         with:
-          branch: "rel-${{ github.event.workflow_run.outputs.version_branch }}"
+          branch: "rel-${{ inputs.version_branch }}"

--- a/.github/workflows/tag-github.yml
+++ b/.github/workflows/tag-github.yml
@@ -5,10 +5,19 @@ name: Tag GitHub
 
 on:
   workflow_call:
-
-  push:
-    paths:
-      - "VERSION"
+    outputs:
+      changed:
+        description: "Whether the VERSION file changed"
+        value: ${{ jobs.tag-github.outputs.changed }}
+      version:
+        description: "The version for the release"
+        value: ${{ jobs.tag-github.outputs.version }}
+      release_branch:
+        description: "Whether there is a need to create a release branch"
+        value: ${{ jobs.tag-github.outputs.release_branch }}
+      version_branch:
+        description: "The name for the need-to-be-created branch"
+        value: ${{ jobs.tag-github.outputs.version_branch }}
 
 jobs:
   tag-github:
@@ -47,31 +56,22 @@ jobs:
           validate="^[0-9]+\.[0-9]+\.[0-9]+$"
 
           if [[ $version =~ $validate ]]; then
-           echo "changed=true" >> $GITHUB_OUTPUT
-           echo "version=$version" >> $GITHUB_OUTPUT
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "version=$version" >> $GITHUB_OUTPUT
           else
-           echo "Version change not for release"
-           exit 0
+            echo "Version change not for release"
           fi
 
           if [[ $version_before =~ $validate ]]; then
-           IFS='.' read -r major minor patch <<< "$version"
-           IFS='.' read -r major_b minor_b patch_b <<< "$version_before"
-           version_branch="$major_b.$minor_b"
-           echo "version_branch=$version_branch" >> $GITHUB_OUTPUT
-           if [[ "$major" -eq "$major_b" ]] && [[ "$minor" -eq "$minor_b" ]]; then
-             echo "Version is compatible with the branch"
-           else
-             echo "Version $version is not compatible with branch version $version_branch"
-             exit 0
-           fi
-           if [[ "$major" -ne "$major_b" ]] || [[ "$minor" -ne "$minor_b" ]]; then
-             echo "release_branch=true" >> $GITHUB_OUTPUT
-             echo "version_branch=$version_branch" >> $GITHUB_OUTPUT
-           fi
+            IFS='.' read -r major minor patch <<< "$version"
+            IFS='.' read -r major_b minor_b patch_b <<< "$version_before"
+            if [[ "$major" -ne "$major_b" ]] || [[ "$minor" -ne "$minor_b" ]]; then
+              version_branch="$major_b.$minor_b"
+              echo "release_branch=true" >> $GITHUB_OUTPUT
+              echo "version_branch=$version_branch" >> $GITHUB_OUTPUT
+            fi
           else
-           echo "Invalid previous version format in VERSION file"
-           exit 1
+            echo "Version change not for branch release"
           fi
 
       - name: Create release using REST API

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,26 +1,28 @@
-# SPDX-License-Identifier: Apache-2.0
 # Copyright 2025 Canonical Ltd.
+# SPDX-FileCopyrightText: 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 name: Update Version
 
 on:
   workflow_call:
-
-  workflow_run:
-    workflows:
-      - "Tag GitHub"
-    types:
-      - completed
+    inputs:
+      version:
+        required: true
+        type: string
+      changed:
+        required: true
+        type: string
 
 jobs:
   update-version:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    if: ${{ inputs.changed == 'true' }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Increment version
         run: |
-          version=${{ github.event.workflow_run.outputs.version }}
+          version=${{ inputs.version }}
           IFS='.' read -r major minor patch <<< "$version"
           patch_update=$((patch+1))
           NEW_VERSION="$major.$minor.$patch_update-dev"


### PR DESCRIPTION
The changes in this PR were tested and successfully create a tag, create/open "update-version" PR and create a branch release.
A few things to point out:
- It seems like there is no effect when passing on.push.paths for the version file in the reusable workflow. This has an effect directly in the repository where the VERSION file changed
- `branch-release` and `update-version` require to get `inputs` and need to be configured when calling the workflows. Moreover, `tag-github` requires to "export its `output` for the other two workflows use them as inputs
- There was some logic about the creation of the branch release that I had to reverse as it was before the workflow consolidation because the new changes were not working as expected.
  - This needs to be revisit and later corrected

We need to update all of our repos as shown in [NAS #99](https://github.com/omec-project/nas/pull/99)