### PR TITLE
fix: Remove slash from docker registries

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -14,7 +14,7 @@ on:
         type: string
       aether_registry:
         description: "Aether Registry URL"
-        default: "registry.aetherproject.org/"
+        default: "registry.aetherproject.org"
         type: string
       aether_repository:
         description: "Aether Repository"
@@ -22,7 +22,7 @@ on:
         type: string
       docker_registry:
         description: "Docker Registry URL"
-        default: "docker.io/"
+        default: "docker.io"
         type: string
       docker_repository:
         description: "Docker Repository"
@@ -57,7 +57,7 @@ jobs:
 
       - name: Build and Push to Docker Registry
         env:
-          DOCKER_REGISTRY: ${{ inputs.docker_registry }}
+          DOCKER_REGISTRY: ${{ inputs.docker_registry }}/
           DOCKER_REPOSITORY: ${{ inputs.docker_repository }}
         run: |
           make docker-build
@@ -72,7 +72,7 @@ jobs:
 
       - name: Build and Push to Aether Registry
         env:
-          DOCKER_REGISTRY: ${{ inputs.aether_registry }}
+          DOCKER_REGISTRY: ${{ inputs.aether_registry }}/
           DOCKER_REPOSITORY: ${{ inputs.aether_repository }}
         run: |
           make docker-build


### PR DESCRIPTION
The trailing slash is present due to how the makefile concatenates the image name. However, this appears to cause issues with docker logging into the registry properly. Therefore, the slash has been removed from the variable, and added to the env var that is used by the makefile.