### PR TITLE
fix: use correct username and password from repo configuration

### DIFF
--- a/.github/workflows/bess-release-image.yml
+++ b/.github/workflows/bess-release-image.yml
@@ -25,8 +25,8 @@ jobs:
         uses: docker/login-action@v3.4.0
         with:
           registry: ${{ inputs.aether_registry }}
-          username: ${{ secrets.AETHER_USERNAME }}
-          password: ${{ secrets.AETHER_PASSWORD }}
+          username: ${{ secrets.AETHER_REGISTRY_USERNAME }}
+          password: ${{ secrets.AETHER_REGISTRY_PASSWORD }}
 
       - name: Build and Push to Aether Registry
         env:


### PR DESCRIPTION
This PR fixes an issue for which BESS release image workflow is not able to fetch username and password from the GitHub repository configuration.