### PR TITLE
fix: use same ubuntu version for BESS build and release

### DIFF
--- a/.github/workflows/bess-release-image.yml
+++ b/.github/workflows/bess-release-image.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   release-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Fix issue preventing Docker to be able to rebuild BESS image for release.