### PR TITLE
chore: get pod logs for E2E tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -87,9 +87,10 @@ jobs:
           REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | cut -d'/' -f2)
           REPO_URL="https://github.com/omec-project/${REPO_NAME}"
 
-          # clone PR branch
-          git clone --depth 1 --branch "${{ github.head_ref }}" "${REPO_URL}" "${REPO_NAME}"
-          cd "${REPO_NAME}"
+          git clone ${REPO_URL} ${REPO_NAME} && cd ${REPO_NAME}
+          PR_NUMBER=$(echo "${GITHUB_REF}" | awk -F'/' '{print $3}')
+          git fetch origin pull/${PR_NUMBER}/merge:pr-${PR_NUMBER}
+          git checkout pr-${PR_NUMBER}
 
           if [ "${REPO_NAME}" = "webconsole" ]; then
             IMAGE_NAME="webui"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -83,14 +83,20 @@ jobs:
       - name: Patch K8s Deployment to attach local image
         run: |
           set -ex
-
           REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | cut -d'/' -f2)
           REPO_URL="https://github.com/omec-project/${REPO_NAME}"
-
+          NAMESPACE="aether-5gc"
+          
           git clone ${REPO_URL} ${REPO_NAME} && cd ${REPO_NAME}
-          PR_NUMBER=$(echo "${GITHUB_REF}" | awk -F'/' '{print $3}')
-          git fetch origin pull/${PR_NUMBER}/merge:pr-${PR_NUMBER}
-          git checkout pr-${PR_NUMBER}
+
+          if [[ "${GITHUB_REF}" == refs/pull/* ]]; then
+            PR_NUMBER=$(echo "${GITHUB_REF}" | awk -F'/' '{print $3}')
+            git fetch origin pull/${PR_NUMBER}/merge:pr-${PR_NUMBER}
+            git checkout pr-${PR_NUMBER}
+          else
+            BRANCH_NAME=$(basename "${GITHUB_REF}")
+            git checkout "${BRANCH_NAME}"
+          fi
 
           if [ "${REPO_NAME}" = "webconsole" ]; then
             IMAGE_NAME="webui"
@@ -99,15 +105,32 @@ jobs:
           fi
 
           docker build -t "${IMAGE_NAME}:testing" .
+          
+          # Save and import Docker image into containerd (used by RKE2) because RKE2 does not use Docker runtime.
+          TMP_DIR="${RUNNER_TEMP:-/tmp}"
+          docker save "${IMAGE_NAME}:testing" -o "${TMP_DIR}/${IMAGE_NAME}.tar"
+          sudo ctr --address /run/k3s/containerd/containerd.sock --namespace k8s.io images import "${TMP_DIR}/${IMAGE_NAME}.tar"
+          sudo ctr --address /run/k3s/containerd/containerd.sock --namespace k8s.io images ls | grep "${IMAGE_NAME}:testing"
 
-          # save and import into containerd for RKE2
-          docker save "${IMAGE_NAME}:testing" -o "/tmp/${IMAGE_NAME}.tar"
-          sudo ctr -n k8s.io images import "/tmp/${IMAGE_NAME}.tar"
-
-          # patch K8s deployment
-          kubectl set image deployment/"${IMAGE_NAME}" "${IMAGE_NAME}=${IMAGE_NAME}:testing" -n aether-5gc
-          kubectl -n aether-5gc patch deployment "${IMAGE_NAME}" \
-            -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"${IMAGE_NAME}\",\"image\":\"${IMAGE_NAME}:testing\",\"imagePullPolicy\":\"Never\"}]}}}}"
+          # Patch K8s deployment with imagePullPolicy Never
+          kubectl -n "$NAMESPACE" patch deployment "${REPO_NAME}" --type='merge' -p "$(cat <<EOF
+          {
+            "spec": {
+              "template": {
+                "spec": {
+                  "containers": [
+                    {
+                      "name": "${IMAGE_NAME}",
+                      "image": "docker.io/library/${IMAGE_NAME}:testing",
+                      "imagePullPolicy": "Never"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+          EOF
+          )"
 
       - name: Install GNBSIM
         working-directory: aether-onramp
@@ -136,15 +159,17 @@ jobs:
         if: always()
         run: |
           set -ex
-          mkdir -p pod-logs
-          for pod in $(kubectl get pods -n aether-5gc -o jsonpath='{.items[*].metadata.name}'); do
-            kubectl logs -n aether-5gc "$pod" > "pod-logs/${pod}.log" 2>&1 || true
-            echo "Collected logs for $pod"
+          NAMESPACE="aether-5gc"
+          mkdir -p logs
+          kubectl get events -A --sort-by='.lastTimestamp' > logs/events.txt
+          kubectl get pods -n "$NAMESPACE" -o wide > logs/pods-summary.txt
+          for pod in $(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}'); do
+            kubectl logs --all-containers -n "$NAMESPACE" "$pod" > "logs/${pod}.log" 2>&1 || true
           done
 
       - name: Upload pod logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: aether-5gc-pod-logs
-          path: pod-logs/
+          name: aether-5gc-logs
+          path: logs/

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
+    env:
+      NAMESPACE: aether-5gc
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -85,7 +87,6 @@ jobs:
           set -ex
           REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | cut -d'/' -f2)
           REPO_URL="https://github.com/omec-project/${REPO_NAME}"
-          NAMESPACE="aether-5gc"
           
           git clone ${REPO_URL} ${REPO_NAME} && cd ${REPO_NAME}
 
@@ -159,7 +160,6 @@ jobs:
         if: always()
         run: |
           set -ex
-          NAMESPACE="aether-5gc"
           mkdir -p logs
           kubectl get events -A --sort-by='.lastTimestamp' > logs/events.txt
           kubectl get pods -n "$NAMESPACE" -o wide > logs/pods-summary.txt

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -83,19 +83,30 @@ jobs:
       - name: Patch K8s Deployment to attach local image
         run: |
           set -ex
+
           REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | cut -d'/' -f2)
           REPO_URL="https://github.com/omec-project/${REPO_NAME}"
-          git clone ${REPO_URL} ${REPO_NAME} && cd ${REPO_NAME}
-          PR_NUMBER=$(echo "${GITHUB_REF}" | awk -F'/' '{print $3}')
-          git fetch origin pull/${PR_NUMBER}/merge:pr-${PR_NUMBER}
-          git checkout pr-${PR_NUMBER}
+
+          # clone PR branch
+          git clone --depth 1 --branch "${{ github.head_ref }}" "${REPO_URL}" "${REPO_NAME}"
+          cd "${REPO_NAME}"
+
           if [ "${REPO_NAME}" = "webconsole" ]; then
-            REPO_NAME="webui"
+            IMAGE_NAME="webui"
+          else
+            IMAGE_NAME="${REPO_NAME}"
           fi
-          docker build -t ${REPO_NAME}:testing .
-          kubectl set image deployment/${REPO_NAME} ${REPO_NAME}=${REPO_NAME}:testing -n aether-5gc
-          kubectl -n aether-5gc patch deployment ${REPO_NAME} \
-          -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"${REPO_NAME}\",\"image\":\"${REPO_NAME}:testing\",\"imagePullPolicy\":\"Never\"}]}}}}"
+
+          docker build -t "${IMAGE_NAME}:testing" .
+
+          # save and import into containerd for RKE2
+          docker save "${IMAGE_NAME}:testing" -o "/tmp/${IMAGE_NAME}.tar"
+          sudo ctr -n k8s.io images import "/tmp/${IMAGE_NAME}.tar"
+
+          # patch K8s deployment
+          kubectl set image deployment/"${IMAGE_NAME}" "${IMAGE_NAME}=${IMAGE_NAME}:testing" -n aether-5gc
+          kubectl -n aether-5gc patch deployment "${IMAGE_NAME}" \
+            -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"${IMAGE_NAME}\",\"image\":\"${IMAGE_NAME}:testing\",\"imagePullPolicy\":\"Never\"}]}}}}"
 
       - name: Install GNBSIM
         working-directory: aether-onramp

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           set -ex
           REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | cut -d'/' -f2)
-          REPO_URL="https://github.com/omec-project/${REPO_NAME}"          
+          REPO_URL="https://github.com/omec-project/${REPO_NAME}"
           git clone ${REPO_URL} ${REPO_NAME} && cd ${REPO_NAME}
 
           if [[ "${GITHUB_REF}" == refs/pull/* ]]; then
@@ -112,24 +112,10 @@ jobs:
           sudo ctr --address /run/k3s/containerd/containerd.sock --namespace k8s.io images ls | grep "${IMAGE_NAME}:testing"
 
           # Patch K8s deployment with imagePullPolicy Never
-          kubectl -n "$NAMESPACE" patch deployment "${REPO_NAME}" --type='merge' -p "$(cat <<EOF
-          {
-            "spec": {
-              "template": {
-                "spec": {
-                  "containers": [
-                    {
-                      "name": "${IMAGE_NAME}",
-                      "image": "docker.io/library/${IMAGE_NAME}:testing",
-                      "imagePullPolicy": "Never"
-                    }
-                  ]
-                }
-              }
-            }
-          }
-          EOF
-          )"
+          kubectl -n "$NAMESPACE" patch deployment "${REPO_NAME}" --type='json' -p='[
+            {"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "docker.io/library/${IMAGE_NAME}:testing"},
+            {"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "Never"}
+          ]'
 
       - name: Install GNBSIM
         working-directory: aether-onramp

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -119,3 +119,20 @@ jobs:
             exit 1
           fi
           echo "Profile Status is successful."
+
+      - name: Dump all pod logs in aether-5gc namespace
+        if: always()
+        run: |
+          set -ex
+          mkdir -p pod-logs
+          for pod in $(kubectl get pods -n aether-5gc -o jsonpath='{.items[*].metadata.name}'); do
+            kubectl logs -n aether-5gc "$pod" > "pod-logs/${pod}.log" 2>&1 || true
+            echo "Collected logs for $pod"
+          done
+
+      - name: Upload pod logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: aether-5gc-pod-logs
+          path: pod-logs/

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -112,10 +112,10 @@ jobs:
           sudo ctr --address /run/k3s/containerd/containerd.sock --namespace k8s.io images ls | grep "${IMAGE_NAME}:testing"
 
           # Patch K8s deployment with imagePullPolicy Never
-          kubectl -n "$NAMESPACE" patch deployment "${REPO_NAME}" --type='json' -p='[
-            {"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "docker.io/library/${IMAGE_NAME}:testing"},
-            {"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "Never"}
-          ]'
+          kubectl -n "$NAMESPACE" patch deployment "$REPO_NAME" --type="json" -p="[
+            {\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/image\", \"value\": \"docker.io/library/${IMAGE_NAME}:testing\"},
+            {\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/imagePullPolicy\", \"value\": \"Never\"}
+          ]"
 
       - name: Install GNBSIM
         working-directory: aether-onramp

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -86,8 +86,7 @@ jobs:
         run: |
           set -ex
           REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | cut -d'/' -f2)
-          REPO_URL="https://github.com/omec-project/${REPO_NAME}"
-          
+          REPO_URL="https://github.com/omec-project/${REPO_NAME}"          
           git clone ${REPO_URL} ${REPO_NAME} && cd ${REPO_NAME}
 
           if [[ "${GITHUB_REF}" == refs/pull/* ]]; then
@@ -106,7 +105,6 @@ jobs:
           fi
 
           docker build -t "${IMAGE_NAME}:testing" .
-          
           # Save and import Docker image into containerd (used by RKE2) because RKE2 does not use Docker runtime.
           TMP_DIR="${RUNNER_TEMP:-/tmp}"
           docker save "${IMAGE_NAME}:testing" -o "${TMP_DIR}/${IMAGE_NAME}.tar"


### PR DESCRIPTION
This PR helps to dump logs from pods belongs to aether-5gc namespace  and upload to pod-logs directory which helps troubleshooting and investigation.