### PR TITLE
Add sleep time to E2E test and export logs for gnbsim

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -117,6 +117,9 @@ jobs:
             {\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/imagePullPolicy\", \"value\": \"Never\"}
           ]"
 
+      - name: Sleep time to give the NF time to sync-up with other NFs
+        run: sleep 60
+
       - name: Install GNBSIM
         working-directory: aether-onramp
         run: |
@@ -150,6 +153,7 @@ jobs:
           for pod in $(kubectl get pods -n "$NAMESPACE" -o jsonpath='{.items[*].metadata.name}'); do
             kubectl logs --all-containers -n "$NAMESPACE" "$pod" > "logs/${pod}.log" 2>&1 || true
           done
+          docker exec -ti gnbsim-1 cat gnbsim.log > logs/gnbsim.log 2>&1
 
       - name: Upload pod logs
         if: always()


### PR DESCRIPTION
It seems that `amf` is not ready yet when the `gNBSim` starts sending requests. because the gnbsim deployment happens as soon as the `amf` is patched with the local image. However, for the case of `Onramp, when the NFs are deployed, there is a 60s sleep time to allow the NFs to sync up before they can start serving requests from the RAN/UEs